### PR TITLE
fix in order to connect to JENSEN-Guest network

### DIFF
--- a/pico_client/CMakeLists.txt
+++ b/pico_client/CMakeLists.txt
@@ -54,7 +54,7 @@ if (PICO_BUILD)
 
   pico_add_extra_outputs(pico_client)
   pico_enable_stdio_usb(pico_client 1)
-  pico_enable_stdio_uart(pico_client 1)
+  pico_enable_stdio_uart(pico_client 0)
 endif()
 
 include(CTest)

--- a/pico_client/src/main.c
+++ b/pico_client/src/main.c
@@ -81,5 +81,5 @@ void init_system() {
     lcd_set_cursor(0, 0);
     lcd_print("System Ready");
 
-    //wifi_init();
+    wifi_init();
 }

--- a/pico_client/src/wifi.c
+++ b/pico_client/src/wifi.c
@@ -10,7 +10,7 @@ int wifi_init(void) {
 
 	cyw43_arch_enable_sta_mode();
 
-	if (cyw43_arch_wifi_connect_timeout_ms("jensen_guest", "passw", CYW43_AUTH_OPEN, 30000)){
+	if (cyw43_arch_wifi_connect_timeout_ms("JENSEN-Guest", "pwd", CYW43_AUTH_WPA2_AES_PSK, 40000)){
 		printf("Anslutning misslyckades\n");
 		return -1;
 	} else {


### PR DESCRIPTION
We use the wrong network protocol for connecting to home/jensen wifi networks. I want this in so I can skip editing it all the time.